### PR TITLE
fix: mention required css import for highlight.js

### DIFF
--- a/styles/src/index.md
+++ b/styles/src/index.md
@@ -29,6 +29,7 @@ Review the [reference](/reference) page to review how this stylesheet formats st
 
   ```html
   <!-- syntax highlighting  -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@latest/build/styles/default.min.css>
   <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@latest/build/highlight.min.js"></script>
   <script>hljs.highlightAll();</script>
   ```


### PR DESCRIPTION
I was just setting up a site with these instructions and found that this was missing. It doesn't actually do highlighting without CSS!