### PR TITLE
Supabase/Turso Fixes

### DIFF
--- a/examples/supabase-astro/src/pages/index.astro
+++ b/examples/supabase-astro/src/pages/index.astro
@@ -3,6 +3,8 @@ import Layout from "../components/Layout.astro";
 import PetCard from "../components/PetCard.astro";
 import { supabase } from "../utils/database";
 
+export const prerender = false;
+
 const { data: pets, error } = await supabase
   .from("pets")
   .select("*")

--- a/examples/turso-astro/src/utils/database.ts
+++ b/examples/turso-astro/src/utils/database.ts
@@ -4,6 +4,6 @@ const tursoUrl = import.meta.env.TURSO_DATABASE_URL as string
 const tursoAuthToken = import.meta.env.TURSO_AUTH_TOKEN as string
 
 export const turso = createClient({
-  url: tursoUrl,
+  url: `libsql://${tursoUrl}`,
   authToken: tursoAuthToken,
 })


### PR DESCRIPTION
This PR fixes the following:
- Snuggles were not being updated in the home page for supabase. Disabled prerender in home page to fix this.
- When using the turso extension, libsql:// is not added to environment variable. Changes turso createClient to include it there instead.