### PR TITLE
updated example site in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A collection of examples and demos for people building the web with Netlify
 - AI Executive Summaries - [Site](https://example-ai-executive-summaries.netlify.app/), [Code](https://github.com/netlify/examples/tree/main/examples/ai-executive-summaries)
 - AI Speech to Content with Groq - [Code](https://github.com/netlify/examples/tree/main/examples/ai-speech-to-content)
 - Block AI bots - [Site](https://example-disallow-ai-bots.netlify.app/), [Code](https://github.com/netlify/examples/tree/main/examples/ai-bot-control)
-- Supabase with Astro - [Site](https://supabase-astro-test.netlify.app/), [Code](https://github.com/netlify/examples/tree/main/examples/supabase-astro)
+- Supabase with Astro - [Site](https://supabase-astro.netlify.app/), [Code](https://github.com/netlify/examples/tree/main/examples/supabase-astro)
 - Turso with Astro - [Site](https://turso-astro.netlify.app/), [Code](https://github.com/netlify/examples/tree/main/examples/turso-astro)
 - Geosimcities: GeoCities with Advanced AI and Langbase - [Site](https://geosimcities.netlify.app/), [Code](https://github.com/netlify/examples/tree/main/examples/geosimcities)
 - User-generated uploads - [Site](https://example-user-uploads-astro-blobs.netlify.app/), [Code](https://github.com/netlify/examples/tree/main/examples/user-image-uploads-astro-blobs)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A collection of examples and demos for people building the web with Netlify
 - AI Speech to Content with Groq - [Code](https://github.com/netlify/examples/tree/main/examples/ai-speech-to-content)
 - Block AI bots - [Site](https://example-disallow-ai-bots.netlify.app/), [Code](https://github.com/netlify/examples/tree/main/examples/ai-bot-control)
 - Supabase with Astro - [Site](https://supabase-astro-test.netlify.app/), [Code](https://github.com/netlify/examples/tree/main/examples/supabase-astro)
-- Turso with Astro - [Site](https://turso-astro-test.netlify.app/), [Code](https://github.com/netlify/examples/tree/main/examples/turso-astro)
+- Turso with Astro - [Site](https://turso-astro.netlify.app/), [Code](https://github.com/netlify/examples/tree/main/examples/turso-astro)
 - Geosimcities: GeoCities with Advanced AI and Langbase - [Site](https://geosimcities.netlify.app/), [Code](https://github.com/netlify/examples/tree/main/examples/geosimcities)
 - User-generated uploads - [Site](https://example-user-uploads-astro-blobs.netlify.app/), [Code](https://github.com/netlify/examples/tree/main/examples/user-image-uploads-astro-blobs)
 - Hydrogen storefront with advanced caching - [Site](https://example-hydrogen-caching.netlify.app/), [Code](https://github.com/netlify/examples/tree/main/examples/frameworks/hydrogen-caching)

--- a/examples/supabase-astro/README.md
+++ b/examples/supabase-astro/README.md
@@ -2,7 +2,7 @@
 
 # Supabase example with Astro
 
-[View this example site here](https://supabase-astro-test.netlify.app/)
+[View this example site here](https://supabase-astro.netlify.app/)
 
 This site shows how you can use Supabase in an Astro project to store and display assets uploaded by users. It displays various pets and lets you look at their pages.
 

--- a/examples/turso-astro/README.md
+++ b/examples/turso-astro/README.md
@@ -2,7 +2,7 @@
 
 # Turso example with Astro
 
-[View this example site here](https://turso-astro-test.netlify.app/)
+[View this example site here](https://turso-astro.netlify.app/)
 
 This site shows how you can use Turso in an Astro project to store and display assets uploaded by users. It displays various pets and lets you look at their pages.
 


### PR DESCRIPTION
Supabase and Turso examples sites weren't updated in README after updating the sites in the Netlify app. This PR updates those urls to match the new site names.